### PR TITLE
Replaced deprecated createObjectURL with stream

### DIFF
--- a/color2.html
+++ b/color2.html
@@ -100,9 +100,9 @@ try {
 
     compatibility.getUserMedia({video: true}, function(stream) {
         try {
-            video.src = compatibility.URL.createObjectURL(stream);
+            video.srcObject = stream;
         } catch (error) {
-            video.src = stream;
+            video.src = compatibility.URL.createObjectURL(stream);
         }
         setTimeout(function() {
             video.play();


### PR DESCRIPTION
createObjectURL  is deprecated https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL